### PR TITLE
Add snack bar product purchase form to update stock

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -13,6 +13,7 @@ import { KitchenDisplayPage } from './pages/kitchen/KitchenDisplayPage';
 import KitchenHistoryPage from './pages/kitchen/KitchenHistoryPage';
 import ProductManagementPage from './pages/products/ProductManagementPage';
 import ProductForm from './components/ProductForm';
+import ProductPurchasePage from './pages/products/ProductPurchasePage';
 import SalesHistoryPage from './pages/sales/SalesHistoryPage';
 
 const AppContent: React.FC = () => {
@@ -58,6 +59,7 @@ const AppContent: React.FC = () => {
     if (pathname.startsWith('/sales/history')) return 'Historial de Ventas';
     if (pathname.startsWith('/products/new')) return 'Nuevo Producto';
     if (pathname.startsWith('/products/edit')) return 'Editar Producto';
+    if (pathname.startsWith('/products/purchase')) return 'Compras';
     if (pathname.startsWith('/products')) return 'Gestión de Productos';
     if (pathname.startsWith('/kitchen/history')) return 'Historial de Comandas';
     if (pathname.startsWith('/kitchen')) return 'Comandas de Cocina';
@@ -83,6 +85,7 @@ const AppContent: React.FC = () => {
             <Route path="/products" element={<ProductManagementPage />} />
             <Route path="/products/new" element={<ProductForm />} />
             <Route path="/products/edit/:id" element={<ProductForm />} />
+            <Route path="/products/purchase" element={<ProductPurchasePage />} />
             <Route path="/kitchen" element={<KitchenDisplayPage />} />
             <Route path="/kitchen/history" element={<KitchenHistoryPage />} />
           </Routes>

--- a/backend/controllers/snackBarController.js
+++ b/backend/controllers/snackBarController.js
@@ -53,6 +53,27 @@ export const updateProduct = async (req, res) => {
   }
 };
 
+// Purchase stock for a snack bar product
+export const purchaseProduct = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { quantity, purchasePrice } = req.body;
+    const product = await SnackBarProduct.findByPk(id);
+    if (!product) {
+      return res.status(404).json({ message: 'Producto no encontrado.' });
+    }
+
+    product.stock = (product.stock || 0) + Number(quantity);
+    if (purchasePrice !== undefined) {
+      product.purchasePrice = purchasePrice;
+    }
+    await product.save();
+    res.status(200).json(product);
+  } catch (error) {
+    res.status(400).json({ message: error.message });
+  }
+};
+
 // Delete a snack bar product
 export const deleteProduct = async (req, res) => {
   try {

--- a/backend/routes/snackbar.js
+++ b/backend/routes/snackbar.js
@@ -1,6 +1,6 @@
 
 import express from 'express';
-import { getSnackBarProducts, getProductById, createProduct, updateProduct, deleteProduct } from '../controllers/snackBarController.js';
+import { getSnackBarProducts, getProductById, createProduct, updateProduct, deleteProduct, purchaseProduct } from '../controllers/snackBarController.js';
 
 const router = express.Router();
 
@@ -8,6 +8,7 @@ router.get('/', getSnackBarProducts);
 router.get('/:id', getProductById);
 router.post('/', createProduct);
 router.put('/:id', updateProduct);
+router.post('/:id/purchase', purchaseProduct);
 router.delete('/:id', deleteProduct);
 
 export default router;

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { DashboardIcon, WorkshopIcon, ShowIcon, SnackBarIcon, LogoIcon, KitchenIcon } from './icons';
-import { Clock, Package, ChevronDown, ChevronUp } from 'lucide-react';
+import { Clock, Package, ChevronDown, ChevronUp, ShoppingCart } from 'lucide-react';
 
 const NavItem: React.FC<{
   icon: React.ReactNode;
@@ -110,6 +110,12 @@ const Sidebar: React.FC<{ isOpen: boolean; toggleSidebar: () => void }> = ({ isO
                   icon={<Package className="h-6 w-6" />}
                   label="Gestión Productos"
                   to="/products"
+                  onClick={toggleSidebar}
+                />
+                <NavItem
+                  icon={<ShoppingCart className="h-6 w-6" />}
+                  label="Compras"
+                  to="/products/purchase"
                   onClick={toggleSidebar}
                 />
                 <NavItem

--- a/pages/products/ProductPurchasePage.tsx
+++ b/pages/products/ProductPurchasePage.tsx
@@ -1,0 +1,98 @@
+import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { SnackBarProduct } from '../../types';
+import { getSnackBarProducts, purchaseSnackBarProduct } from '../../services/api';
+
+const ProductPurchasePage: React.FC = () => {
+  const [products, setProducts] = useState<SnackBarProduct[]>([]);
+  const [selectedProductId, setSelectedProductId] = useState('');
+  const [quantity, setQuantity] = useState<number>(0);
+  const [purchasePrice, setPurchasePrice] = useState<number>(0);
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getSnackBarProducts()
+      .then(setProducts)
+      .catch(() => setError('Error al cargar los productos.'));
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedProductId) return;
+    try {
+      setLoading(true);
+      await purchaseSnackBarProduct(selectedProductId, quantity, purchasePrice);
+      setMessage('Stock actualizado correctamente.');
+      setError(null);
+      setQuantity(0);
+      setPurchasePrice(0);
+    } catch (err) {
+      setError('Error al actualizar el stock.');
+      setMessage(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-6 bg-gray-100 dark:bg-brand-dark min-h-screen">
+      <h1 className="text-4xl font-bold mb-6 text-gray-800 dark:text-white">Compras</h1>
+      {message && <p className="text-green-500 bg-green-100 p-3 rounded-md">{message}</p>}
+      {error && <p className="text-red-500 bg-red-100 p-3 rounded-md">{error}</p>}
+      <form onSubmit={handleSubmit} className="bg-white dark:bg-brand-navy p-6 rounded-lg shadow-lg">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+          <div>
+            <label htmlFor="product" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Producto:</label>
+            <select
+              id="product"
+              value={selectedProductId}
+              onChange={(e) => setSelectedProductId(e.target.value)}
+              required
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-brand-accent focus:ring-brand-accent dark:bg-brand-dark dark:border-gray-600 dark:text-white"
+            >
+              <option value="">Seleccionar...</option>
+              {products.map((p) => (
+                <option key={p.id} value={p.id}>{p.name}</option>
+              ))}
+            </select>
+            <Link to="/products/new" className="text-blue-600 hover:underline text-sm mt-2 inline-block">Crear nuevo producto</Link>
+          </div>
+          <div>
+            <label htmlFor="quantity" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Cantidad:</label>
+            <input
+              type="number"
+              id="quantity"
+              value={quantity}
+              onChange={(e) => setQuantity(parseInt(e.target.value))}
+              required
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-brand-accent focus:ring-brand-accent dark:bg-brand-dark dark:border-gray-600 dark:text-white"
+            />
+          </div>
+          <div>
+            <label htmlFor="purchasePrice" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Precio de Compra:</label>
+            <input
+              type="number"
+              step="0.01"
+              id="purchasePrice"
+              value={purchasePrice}
+              onChange={(e) => setPurchasePrice(parseFloat(e.target.value))}
+              required
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-brand-accent focus:ring-brand-accent dark:bg-brand-dark dark:border-gray-600 dark:text-white"
+            />
+          </div>
+        </div>
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg transition-colors disabled:bg-gray-400 disabled:cursor-not-allowed"
+        >
+          {loading ? 'Guardando...' : 'Actualizar Stock'}
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default ProductPurchasePage;

--- a/services/api.ts
+++ b/services/api.ts
@@ -114,6 +114,11 @@ export const deleteSnackBarProduct = async (id: string): Promise<void> => {
     await api.delete(`/snackbar/${id}`);
 };
 
+export const purchaseSnackBarProduct = async (id: string, quantity: number, purchasePrice: number): Promise<SnackBarProduct> => {
+    const response = await api.post(`/snackbar/${id}/purchase`, { quantity, purchasePrice });
+    return response.data;
+};
+
 export const confirmSale = async (order: OrderItem[], tableNumber: number) => {
     const response = await api.post('/sales/confirm', { order, tableNumber });
     return response.data;


### PR DESCRIPTION
## Summary
- allow server to increase product stock via new `/snackbar/:id/purchase` endpoint
- expose purchase API and UI form with dropdown to select products and link to create new ones
- add navigation link for purchases

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689a565e0524832a86c0977437b28a47