### PR TITLE
Add payment method handling for snack bar sales

### DIFF
--- a/backend/controllers/saleController.js
+++ b/backend/controllers/saleController.js
@@ -1,7 +1,7 @@
 import { KitchenOrder, KitchenOrderItem, SnackBarProduct, SnackBarSale, SnackBarSaleItem, sequelize } from '../models/index.js';
 
 const confirmSale = async (req, res) => {
-    const { order, tableNumber } = req.body;
+    const { order, tableNumber, paymentMethod } = req.body;
     const t = await sequelize.transaction();
 
     try {
@@ -13,7 +13,8 @@ const confirmSale = async (req, res) => {
         // Create SnackBarSale record
         const newSale = await SnackBarSale.create({
             total: totalSaleAmount,
-            saleDate: new Date()
+            saleDate: new Date(),
+            paymentMethod
         }, { transaction: t });
 
         // Create SnackBarSaleItem records
@@ -91,3 +92,5 @@ const getSalesHistory = async (req, res) => {
 };
 
 export default { confirmSale, getSalesHistory };
+
+

--- a/backend/models/SnackBarSale.js
+++ b/backend/models/SnackBarSale.js
@@ -4,6 +4,13 @@ export default (sequelize, DataTypes) => {
             type: DataTypes.DECIMAL(10, 2),
             allowNull: false
         },
+        paymentMethod: {
+            type: DataTypes.STRING,
+            allowNull: false,
+            validate: {
+                isIn: [['Efectivo', 'Transferencia', 'Tarjeta']]
+            }
+        },
         saleDate: {
             type: DataTypes.DATE,
             defaultValue: DataTypes.NOW
@@ -21,3 +28,5 @@ export default (sequelize, DataTypes) => {
 
     return SnackBarSale;
 };
+
+

--- a/backend/routes/sales.js
+++ b/backend/routes/sales.js
@@ -3,7 +3,14 @@ import saleController from '../controllers/saleController.js';
 
 const router = express.Router();
 
-router.post('/confirm', saleController.confirmSale);
+// Expect { order, tableNumber, paymentMethod } in body
+router.post('/confirm', (req, res, next) => {
+    if (!req.body.paymentMethod) {
+        return res.status(400).json({ message: 'paymentMethod is required' });
+    }
+    next();
+}, saleController.confirmSale);
 router.get('/history', saleController.getSalesHistory);
 
 export default router;
+

--- a/pages/snackbar/SnackBarPOSPage.tsx
+++ b/pages/snackbar/SnackBarPOSPage.tsx
@@ -14,6 +14,7 @@ const SnackBarPOSPage: React.FC = () => {
     const [isTicketModalOpen, setIsTicketModalOpen] = useState(false);
     const [pizzaToAdd, setPizzaToAdd] = useState<SnackBarProduct | null>(null);
     const [lastSale, setLastSale] = useState<SnackBarSale | null>(null);
+    const [paymentMethod, setPaymentMethod] = useState<'Efectivo' | 'Transferencia' | 'Tarjeta'>('Efectivo');
 
     useEffect(() => {
         const fetchProducts = async () => {
@@ -72,7 +73,11 @@ const SnackBarPOSPage: React.FC = () => {
             return;
         }
         try {
-            const result = await confirmSale(order.map(item => ({ ...item, isHalf: item.isHalf || false })), tableNumber as number);
+            const result = await confirmSale(
+                order.map(item => ({ ...item, isHalf: item.isHalf || false })),
+                tableNumber as number,
+                paymentMethod
+            );
             setLastSale(result.sale);
             setIsTicketModalOpen(true);
             
@@ -81,6 +86,7 @@ const SnackBarPOSPage: React.FC = () => {
 
             setOrder([]);
             setTableNumber(0);
+            setPaymentMethod('Efectivo');
         } catch (error) {
             alert("Error al confirmar la venta.");
         }
@@ -185,6 +191,26 @@ const SnackBarPOSPage: React.FC = () => {
                         <span>TOTAL:</span>
                         <span className="text-brand-accent">${total.toLocaleString()}</span>
                     </div>
+                    <div className="grid grid-cols-3 gap-3 mb-4">
+                        <button
+                            onClick={() => setPaymentMethod('Efectivo')}
+                            className={`bg-green-600 hover:bg-green-700 text-white font-bold py-2 rounded-lg transition-colors ${paymentMethod === 'Efectivo' ? 'ring-4 ring-green-300' : ''}`}
+                        >
+                            Efectivo
+                        </button>
+                        <button
+                            onClick={() => setPaymentMethod('Transferencia')}
+                            className={`bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 rounded-lg transition-colors ${paymentMethod === 'Transferencia' ? 'ring-4 ring-blue-300' : ''}`}
+                        >
+                            Transferencia
+                        </button>
+                        <button
+                            onClick={() => setPaymentMethod('Tarjeta')}
+                            className={`bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 rounded-lg transition-colors ${paymentMethod === 'Tarjeta' ? 'ring-4 ring-purple-300' : ''}`}
+                        >
+                            Tarjeta
+                        </button>
+                    </div>
                     <div className="grid grid-cols-2 gap-3">
                         <button onClick={() => setOrder([])} className="bg-gray-600 hover:bg-gray-700 text-white font-bold py-3 rounded-lg transition-colors">Limpiar</button>
                         <button onClick={handleConfirmSale} disabled={order.length === 0} className="bg-green-600 hover:bg-green-700 text-white font-bold py-3 rounded-lg transition-colors disabled:bg-gray-500 disabled:cursor-not-allowed">Cobrar</button>
@@ -214,3 +240,4 @@ const SnackBarPOSPage: React.FC = () => {
 };
 
 export default SnackBarPOSPage;
+

--- a/services/api.ts
+++ b/services/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { Workshop, Student, Show, SnackBarProduct, SnackBarProductCategory, SnackBarProductDelivery, KitchenOrder } from '../types';
+import { Workshop, Student, Show, SnackBarProduct, SnackBarProductCategory, SnackBarProductDelivery, KitchenOrder, OrderItem, SnackBarSale } from '../types';
 
 const API_BASE_URL = 'http://69.62.95.248:8080/api';
 
@@ -119,8 +119,12 @@ export const purchaseSnackBarProduct = async (id: string, quantity: number, purc
     return response.data;
 };
 
-export const confirmSale = async (order: OrderItem[], tableNumber: number) => {
-    const response = await api.post('/sales/confirm', { order, tableNumber });
+export const confirmSale = async (
+    order: OrderItem[],
+    tableNumber: number,
+    paymentMethod: 'Efectivo' | 'Transferencia' | 'Tarjeta'
+) => {
+    const response = await api.post('/sales/confirm', { order, tableNumber, paymentMethod });
     return response.data;
 };
 
@@ -139,3 +143,4 @@ export const updateOrderStatus = async (orderId: number, status: 'pendiente' | '
     const response = await api.patch(`/kitchen/${orderId}/status`, { status });
     return response.data;
 };
+

--- a/types.ts
+++ b/types.ts
@@ -127,5 +127,8 @@ export interface SnackBarSale {
   id: number;
   total: number;
   saleDate: string;
+  paymentMethod: 'Efectivo' | 'Transferencia' | 'Tarjeta';
   items: SnackBarSaleItem[];
 }
+
+


### PR DESCRIPTION
## Summary
- allow selecting payment method in POS UI and pass to backend
- store payment method in snack bar sales and validate on route
- update types and API client for new field

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689abb9b9058832a916da2525f692159