### PR TITLE
feat: enable schema alterations for snackbar sales

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -20,7 +20,7 @@ app.use('/api/sales', salesRoutes); // New route
 
 const PORT = process.env.PORT || 8080;
 
-sequelize.sync().then(() => {
+sequelize.sync({ alter: true }).then(() => {
   app.listen(PORT, () => {
     console.log(`Server is running on port ${PORT}.`);
   });


### PR DESCRIPTION
## Summary
- allow Sequelize to alter the schema when starting the backend

## Testing
- `npm test` (fails: Missing script)
- `node backend/server.js` (fails: connect ECONNREFUSED 127.0.0.1:3306)


------
https://chatgpt.com/codex/tasks/task_e_689d0db837d8832a920eb45a071fabbc