### PR TITLE
Reemplaza selector de mesa por modal obligatorio

### DIFF
--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -6,9 +6,10 @@ interface ModalProps {
   onClose: () => void;
   title: string;
   children: React.ReactNode;
+  hideCloseButton?: boolean;
 }
 
-const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
+const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, hideCloseButton = false }) => {
   if (!isOpen) return null;
 
   return (
@@ -16,14 +17,16 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
       <div className="bg-white dark:bg-brand-navy rounded-lg shadow-2xl w-full max-w-2xl max-h-[90vh] flex flex-col">
         <div className="flex justify-between items-center p-4 border-b border-gray-200 dark:border-brand-blue">
           <h2 className="text-xl font-bold text-gray-800 dark:text-white">{title}</h2>
-          <button
-            onClick={onClose}
-            className="text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-white transition-colors"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
+          {!hideCloseButton && (
+            <button
+              onClick={onClose}
+              className="text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-white transition-colors"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
         </div>
         <div className="p-6 overflow-y-auto">
           {children}

--- a/pages/snackbar/SnackBarPOSPage.tsx
+++ b/pages/snackbar/SnackBarPOSPage.tsx
@@ -3,15 +3,17 @@ import React, { useState, useEffect } from 'react';
 import { SnackBarProduct, OrderItem, SnackBarSale } from '../../types';
 import { getSnackBarProducts, confirmSale } from '../../services/api';
 import Modal from '../../components/Modal';
-import TicketModal from './TicketModal'; // Assuming this will be the new component
+import TicketModal from './TicketModal';
+import TableNumberModal from './TableNumberModal';
 
 const SnackBarPOSPage: React.FC = () => {
     const [products, setProducts] = useState<SnackBarProduct[]>([]);
     const [order, setOrder] = useState<OrderItem[]>([]);
-    const [tableNumber, setTableNumber] = useState<number | ''>(0);
+    const [tableNumber, setTableNumber] = useState<number>(0);
     const [loading, setLoading] = useState(true);
     const [isPizzaModalOpen, setIsPizzaModalOpen] = useState(false);
     const [isTicketModalOpen, setIsTicketModalOpen] = useState(false);
+    const [isTableModalOpen, setIsTableModalOpen] = useState(true);
     const [pizzaToAdd, setPizzaToAdd] = useState<SnackBarProduct | null>(null);
     const [lastSale, setLastSale] = useState<SnackBarSale | null>(null);
     const [paymentMethod, setPaymentMethod] = useState<'Efectivo' | 'Transferencia' | 'Tarjeta'>('Efectivo');
@@ -68,14 +70,14 @@ const SnackBarPOSPage: React.FC = () => {
 
     const handleConfirmSale = async () => {
         if (order.length === 0) return;
-        if (tableNumber === '') {
-            alert("Por favor, ingrese un número de mesa válido.");
+        if (!tableNumber) {
+            alert("Por favor, seleccione un número de mesa válido.");
             return;
         }
         try {
             const result = await confirmSale(
                 order.map(item => ({ ...item, isHalf: item.isHalf || false })),
-                tableNumber as number,
+                tableNumber,
                 paymentMethod
             );
             setLastSale(result.sale);
@@ -158,15 +160,8 @@ const SnackBarPOSPage: React.FC = () => {
                 <div className="flex justify-between items-center mb-4">
                     <h3 className="text-xl font-bold text-gray-800 dark:text-white">Pedido Actual</h3>
                     <div className="flex items-center">
-                        <label htmlFor="tableNumber" className="text-sm font-medium text-gray-700 dark:text-gray-300 mr-2">Mesa:</label>
-                        <input
-                            type="number"
-                            id="tableNumber"
-                            value={tableNumber}
-                            onChange={(e) => setTableNumber(e.target.value === '' ? '' : parseInt(e.target.value))}
-                            className="w-20 rounded-md border-gray-300 shadow-sm focus:border-brand-accent focus:ring-brand-accent sm:text-sm dark:bg-brand-dark dark:border-gray-600 dark:text-white text-center"
-                            placeholder="#"
-                        />
+                        <span className="text-sm font-medium text-gray-700 dark:text-gray-300 mr-2">Mesa:</span>
+                        <span className="text-lg font-bold text-gray-800 dark:text-white">{tableNumber || '--'}</span>
                     </div>
                 </div>
                 <div className="flex-grow overflow-y-auto pr-2">
@@ -229,12 +224,23 @@ const SnackBarPOSPage: React.FC = () => {
             </Modal>
 
             {lastSale && (
-                <TicketModal 
-                    isOpen={isTicketModalOpen} 
-                    onClose={() => setIsTicketModalOpen(false)} 
-                    sale={lastSale} 
+                <TicketModal
+                    isOpen={isTicketModalOpen}
+                    onClose={() => {
+                        setIsTicketModalOpen(false);
+                        setIsTableModalOpen(true);
+                    }}
+                    sale={lastSale}
                 />
             )}
+
+            <TableNumberModal
+                isOpen={isTableModalOpen}
+                onSelect={(num) => {
+                    setTableNumber(num);
+                    setIsTableModalOpen(false);
+                }}
+            />
         </div>
     );
 };

--- a/pages/snackbar/TableNumberModal.tsx
+++ b/pages/snackbar/TableNumberModal.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import Modal from '../../components/Modal';
+
+interface TableNumberModalProps {
+    isOpen: boolean;
+    onSelect: (number: number) => void;
+}
+
+const TableNumberModal: React.FC<TableNumberModalProps> = ({ isOpen, onSelect }) => {
+    const numbers = Array.from({ length: 20 }, (_, i) => i + 1);
+
+    return (
+        <Modal isOpen={isOpen} onClose={() => {}} title="Seleccionar mesa" hideCloseButton>
+            <div className="grid grid-cols-5 gap-4">
+                {numbers.map(num => (
+                    <button
+                        key={num}
+                        onClick={() => onSelect(num)}
+                        className="bg-gray-200 hover:bg-gray-300 dark:bg-brand-blue dark:hover:bg-opacity-80 text-gray-800 dark:text-white font-bold py-3 rounded-lg"
+                    >
+                        {num}
+                    </button>
+                ))}
+            </div>
+        </Modal>
+    );
+};
+
+export default TableNumberModal;


### PR DESCRIPTION
## Summary
- Elimina el input de mesa del POS y muestra el número seleccionado en forma no editable
- Agrega `TableNumberModal` con 20 botones que se abre al iniciar y tras cerrar el ticket de venta
- Permite ocultar el botón de cierre en `Modal` para exigir la selección de mesa

## Testing
- `npm test` *(falla: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b66bcf91ac832aaf9854fa7de78bbb