### PR TITLE
Reemplaza selector de mesa por modal obligatorio

### DIFF
--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -6,9 +6,10 @@ interface ModalProps {
   onClose: () => void;
   title: string;
   children: React.ReactNode;
+  hideCloseButton?: boolean;
 }
 
-const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
+const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, hideCloseButton = false }) => {
   if (!isOpen) return null;
 
   return (
@@ -16,14 +17,16 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
       <div className="bg-white dark:bg-brand-navy rounded-lg shadow-2xl w-full max-w-2xl max-h-[90vh] flex flex-col">
         <div className="flex justify-between items-center p-4 border-b border-gray-200 dark:border-brand-blue">
           <h2 className="text-xl font-bold text-gray-800 dark:text-white">{title}</h2>
-          <button
-            onClick={onClose}
-            className="text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-white transition-colors"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
+          {!hideCloseButton && (
+            <button
+              onClick={onClose}
+              className="text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-white transition-colors"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
         </div>
         <div className="p-6 overflow-y-auto">
           {children}

--- a/pages/snackbar/TableNumberModal.tsx
+++ b/pages/snackbar/TableNumberModal.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import Modal from '../../components/Modal';
+
+interface TableNumberModalProps {
+    isOpen: boolean;
+    onSelect: (number: number, customerName?: string) => void;
+}
+
+const TableNumberModal: React.FC<TableNumberModalProps> = ({ isOpen, onSelect }) => {
+    const numbers = Array.from({ length: 20 }, (_, i) => i + 1);
+    const [customerName, setCustomerName] = useState('');
+
+    return (
+        <Modal isOpen={isOpen} onClose={() => {}} title="Seleccionar mesa" hideCloseButton>
+            <div className="mb-4">
+                <input
+                    type="text"
+                    placeholder="Nombre del cliente (opcional)"
+                    value={customerName}
+                    onChange={e => setCustomerName(e.target.value)}
+                    className="w-full p-2 border rounded"
+                />
+            </div>
+            <div className="grid grid-cols-5 gap-4">
+                {numbers.map(num => (
+                    <button
+                        key={num}
+                        onClick={() => { onSelect(num); setCustomerName(''); }}
+                        className="bg-gray-200 hover:bg-gray-300 dark:bg-brand-blue dark:hover:bg-opacity-80 text-gray-800 dark:text-white font-bold py-3 rounded-lg"
+                    >
+                        {num}
+                    </button>
+                ))}
+            </div>
+            <button
+                onClick={() => { onSelect(0, customerName); setCustomerName(''); }}
+                className="mt-4 w-full bg-gray-200 hover:bg-gray-300 dark:bg-brand-blue dark:hover:bg-opacity-80 text-gray-800 dark:text-white font-bold py-3 rounded-lg"
+            >
+                Barra
+            </button>
+        </Modal>
+    );
+};
+
+export default TableNumberModal;


### PR DESCRIPTION
## Summary
- Elimina el input de mesa del POS y muestra el número seleccionado en forma no editable
- Agrega `TableNumberModal` con 20 botones que se abre al iniciar y tras cerrar el ticket de venta
- Permite ocultar el botón de cierre en `Modal` para exigir la selección de mesa
- Añade botón **Barra** y campo opcional para nombre del cliente

## Testing
- `npm test` *(falla: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b66bcf91ac832aaf9854fa7de78bbb