### PR TITLE
Add combo models and CRUD endpoints

### DIFF
--- a/backend/controllers/comboController.js
+++ b/backend/controllers/comboController.js
@@ -1,0 +1,100 @@
+import Combo from '../models/Combo.js';
+import ComboItem from '../models/ComboItem.js';
+import SnackBarProduct from '../models/SnackBarProduct.js';
+
+export const getCombos = async (req, res) => {
+  try {
+    const combos = await Combo.findAll({
+      include: {
+        model: ComboItem,
+        as: 'items',
+        include: { model: SnackBarProduct, as: 'options', through: { attributes: [] } }
+      }
+    });
+    res.json(combos);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const getComboById = async (req, res) => {
+  try {
+    const combo = await Combo.findByPk(req.params.id, {
+      include: {
+        model: ComboItem,
+        as: 'items',
+        include: { model: SnackBarProduct, as: 'options', through: { attributes: [] } }
+      }
+    });
+    if (combo) {
+      res.json(combo);
+    } else {
+      res.status(404).json({ message: 'Combo no encontrado.' });
+    }
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const createCombo = async (req, res) => {
+  try {
+    const { name, price, items } = req.body;
+    const combo = await Combo.create({ id: `combo_${Date.now()}`, name, price });
+
+    if (Array.isArray(items)) {
+      for (const item of items) {
+        const comboItem = await ComboItem.create({ comboId: combo.id, label: item.label });
+        if (Array.isArray(item.productIds) && item.productIds.length) {
+          const products = await SnackBarProduct.findAll({ where: { id: item.productIds } });
+          await comboItem.setOptions(products);
+        }
+      }
+    }
+
+    const created = await Combo.findByPk(combo.id, {
+      include: {
+        model: ComboItem,
+        as: 'items',
+        include: { model: SnackBarProduct, as: 'options', through: { attributes: [] } }
+      }
+    });
+    res.status(201).json(created);
+  } catch (error) {
+    res.status(400).json({ message: error.message });
+  }
+};
+
+export const updateCombo = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const [updated] = await Combo.update(req.body, { where: { id } });
+    if (updated) {
+      const combo = await Combo.findByPk(id, {
+        include: {
+          model: ComboItem,
+          as: 'items',
+          include: { model: SnackBarProduct, as: 'options', through: { attributes: [] } }
+        }
+      });
+      res.status(200).json(combo);
+    } else {
+      res.status(404).json({ message: 'Combo no encontrado.' });
+    }
+  } catch (error) {
+    res.status(400).json({ message: error.message });
+  }
+};
+
+export const deleteCombo = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const deleted = await Combo.destroy({ where: { id } });
+    if (deleted) {
+      res.status(204).send();
+    } else {
+      res.status(404).json({ message: 'Combo no encontrado.' });
+    }
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};

--- a/backend/models/Combo.js
+++ b/backend/models/Combo.js
@@ -1,0 +1,22 @@
+import { DataTypes } from 'sequelize';
+import sequelize from '../config/database.js';
+
+const Combo = sequelize.define('Combo', {
+  id: {
+    type: DataTypes.STRING,
+    primaryKey: true,
+  },
+  name: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  price: {
+    type: DataTypes.DECIMAL(10, 2),
+    allowNull: false,
+  },
+}, {
+  tableName: 'combos',
+  timestamps: false,
+});
+
+export default Combo;

--- a/backend/models/ComboItem.js
+++ b/backend/models/ComboItem.js
@@ -1,0 +1,23 @@
+import { DataTypes } from 'sequelize';
+import sequelize from '../config/database.js';
+
+const ComboItem = sequelize.define('ComboItem', {
+  id: {
+    type: DataTypes.INTEGER,
+    autoIncrement: true,
+    primaryKey: true,
+  },
+  comboId: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  label: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+}, {
+  tableName: 'combo_items',
+  timestamps: false,
+});
+
+export default ComboItem;

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -1,4 +1,3 @@
-
 import { DataTypes } from 'sequelize';
 import sequelize from '../config/database.js'; // Import sequelize instance
 
@@ -7,6 +6,8 @@ import Workshop from './Workshop.js';
 import Student from './Student.js';
 import Show from './Show.js';
 import SnackBarProduct from './SnackBarProduct.js';
+import Combo from './Combo.js';
+import ComboItem from './ComboItem.js';
 
 // Import model functions and initialize them
 import _KitchenOrder from './KitchenOrder.js';
@@ -33,6 +34,26 @@ KitchenOrderItem.belongsTo(SnackBarProduct, { as: 'product', foreignKey: 'produc
 SnackBarProduct.hasMany(SnackBarPurchase, { as: 'purchases', foreignKey: 'product_id' });
 SnackBarPurchase.belongsTo(SnackBarProduct, { as: 'product', foreignKey: 'product_id' });
 
+// Combo-ComboItem Association
+Combo.hasMany(ComboItem, { as: 'items', foreignKey: 'comboId' });
+ComboItem.belongsTo(Combo, { as: 'combo', foreignKey: 'comboId' });
+
+// ComboItem-SnackBarProduct Association (options)
+ComboItem.belongsToMany(SnackBarProduct, {
+  through: 'comboitem_products',
+  as: 'options',
+  foreignKey: 'combo_item_id',
+  otherKey: 'product_id',
+  timestamps: false,
+});
+SnackBarProduct.belongsToMany(ComboItem, {
+  through: 'comboitem_products',
+  as: 'comboItems',
+  foreignKey: 'product_id',
+  otherKey: 'combo_item_id',
+  timestamps: false,
+});
+
 // Import model functions and initialize them
 import _SnackBarSale from './SnackBarSale.js';
 import _SnackBarSaleItem from './SnackBarSaleItem.js';
@@ -44,5 +65,17 @@ const SnackBarSaleItem = _SnackBarSaleItem(sequelize, DataTypes);
 SnackBarSale.hasMany(SnackBarSaleItem, { as: 'items', foreignKey: 'sale_id' });
 SnackBarSaleItem.belongsTo(SnackBarSale, { as: 'sale', foreignKey: 'sale_id' });
 
-
-export { Workshop, Student, Show, SnackBarProduct, KitchenOrder, KitchenOrderItem, SnackBarPurchase, SnackBarSale, SnackBarSaleItem, sequelize };
+export {
+  Workshop,
+  Student,
+  Show,
+  SnackBarProduct,
+  Combo,
+  ComboItem,
+  KitchenOrder,
+  KitchenOrderItem,
+  SnackBarPurchase,
+  SnackBarSale,
+  SnackBarSaleItem,
+  sequelize,
+};

--- a/backend/routes/combos.js
+++ b/backend/routes/combos.js
@@ -1,0 +1,12 @@
+import express from 'express';
+import { getCombos, getComboById, createCombo, updateCombo, deleteCombo } from '../controllers/comboController.js';
+
+const router = express.Router();
+
+router.get('/', getCombos);
+router.get('/:id', getComboById);
+router.post('/', createCombo);
+router.put('/:id', updateCombo);
+router.delete('/:id', deleteCombo);
+
+export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -7,6 +7,7 @@ import showRoutes from './routes/shows.js';
 import snackbarRoutes from './routes/snackbar.js';
 import kitchenRoutes from './routes/kitchen.js';
 import salesRoutes from './routes/sales.js'; // New import
+import comboRoutes from './routes/combos.js';
 
 const app = express();
 app.use(cors());
@@ -17,6 +18,7 @@ app.use('/api/shows', showRoutes);
 app.use('/api/snackbar', snackbarRoutes);
 app.use('/api/kitchen', kitchenRoutes);
 app.use('/api/sales', salesRoutes); // New route
+app.use('/api/combos', comboRoutes);
 
 const PORT = process.env.PORT || 8080;
 

--- a/services/api.ts
+++ b/services/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { Workshop, Student, Show, SnackBarProduct, SnackBarProductCategory, SnackBarProductDelivery, KitchenOrder, OrderItem, SnackBarSale } from '../types';
+import { Workshop, Student, Show, SnackBarProduct, SnackBarProductCategory, SnackBarProductDelivery, KitchenOrder, OrderItem, SnackBarSale, Combo} from '../types';
 
 const API_BASE_URL = 'http://69.62.95.248:8080/api';
 
@@ -117,6 +117,31 @@ export const deleteSnackBarProduct = async (id: string): Promise<void> => {
 export const purchaseSnackBarProduct = async (id: string, quantity: number, purchasePrice: number): Promise<SnackBarProduct> => {
     const response = await api.post(`/snackbar/${id}/purchase`, { quantity, purchasePrice });
     return response.data;
+};
+
+
+export const getCombos = async (): Promise<Combo[]> => {
+    const response = await api.get('/combos');
+    return response.data;
+};
+
+export const getComboById = async (id: string): Promise<Combo> => {
+    const response = await api.get(`/combos/${id}`);
+    return response.data;
+};
+
+export const createCombo = async (combo: Omit<Combo, 'id'>): Promise<Combo> => {
+    const response = await api.post('/combos', combo);
+    return response.data;
+};
+
+export const updateCombo = async (id: string, combo: Partial<Combo>): Promise<Combo> => {
+    const response = await api.put(`/combos/${id}`, combo);
+    return response.data;
+};
+
+export const deleteCombo = async (id: string): Promise<void> => {
+    await api.delete(`/combos/${id}`);
 };
 
 export const confirmSale = async (

--- a/types.ts
+++ b/types.ts
@@ -133,3 +133,16 @@ export interface SnackBarSale {
 }
 
 
+export interface ComboItem {
+  id: number;
+  comboId: string;
+  label: string;
+  options: SnackBarProduct[];
+}
+
+export interface Combo {
+  id: string;
+  name: string;
+  price: number;
+  items: ComboItem[];
+}


### PR DESCRIPTION
## Summary
- add Combo and ComboItem models with associations to snack bar products
- implement combo controller and routes for CRUD operations
- expose /api/combos endpoint and update frontend API/types

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6edbd3a50832aaadff6d70bfcc479