### PR TITLE
Define combo-item foreign key and add table creation script

### DIFF
--- a/backend/models/Combo.js
+++ b/backend/models/Combo.js
@@ -5,6 +5,7 @@ const Combo = sequelize.define('Combo', {
   id: {
     type: DataTypes.STRING,
     primaryKey: true,
+    allowNull: false,
   },
   name: {
     type: DataTypes.STRING,

--- a/backend/models/ComboItem.js
+++ b/backend/models/ComboItem.js
@@ -10,6 +10,11 @@ const ComboItem = sequelize.define('ComboItem', {
   comboId: {
     type: DataTypes.STRING,
     allowNull: false,
+    references: {
+      model: 'combos',
+      key: 'id',
+    },
+    field: 'combo_id',
   },
   name: {
     type: DataTypes.STRING,

--- a/combos_tables.sql
+++ b/combos_tables.sql
@@ -1,0 +1,14 @@
+-- Table for snack bar combos
+CREATE TABLE combos (
+    id VARCHAR(255) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    price DECIMAL(10, 2) NOT NULL
+);
+
+-- Table for items inside a combo
+CREATE TABLE combo_items (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    combo_id VARCHAR(255) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    FOREIGN KEY (combo_id) REFERENCES combos(id)
+);


### PR DESCRIPTION
## Summary
- Enforce non-null primary key on Combo model
- Link ComboItem.comboId to combos.id and map to `combo_id`
- Provide SQL script for creating `combos` and `combo_items` tables

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm --prefix backend test` *(fails: Missing script: "test")*
- `node backend/server.js` *(fails: connect ECONNREFUSED 127.0.0.1:3306)*

------
https://chatgpt.com/codex/tasks/task_e_68b7542b94d4832aabf74e48a2164056