### PR TITLE
feat: make API base URL configurable via env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://69.62.95.248:8080/api

--- a/services/api.ts
+++ b/services/api.ts
@@ -2,8 +2,7 @@ import axios from 'axios';
 
 import { Workshop, Student, Show, SnackBarProduct, SnackBarProductCategory, SnackBarProductDelivery, KitchenOrder, OrderItem, SnackBarSale, SnackBarCombo, OrderCombo, Combo } from '../types';
 
-
-const API_BASE_URL = 'http://69.62.95.248:8080/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 export const api = axios.create({
   baseURL: API_BASE_URL,


### PR DESCRIPTION
## Summary
- allow overriding API base URL via `VITE_API_BASE_URL`
- add example `.env` with `VITE_API_BASE_URL`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b75be70030832a8b4b0ee2d407b3b5