### PR TITLE
fix: remove importmap for react

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,16 +8,7 @@
     <title>Onírico Sur - Gestión Teatral</title>
     <link rel="preconnect" href="https://rsms.me/">
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
-    <script type="importmap">
-{
-  "imports": {
-    "react": "https://esm.sh/react@^19.1.0",
-    "react-dom/": "https://esm.sh/react-dom@^19.1.0/",
-    "react/": "https://esm.sh/react@^19.1.0/"
-  }
-}
-</script>
-</head>
+  </head>
   <body class="bg-gray-100 dark:bg-brand-dark text-gray-800 dark:text-brand-light">
     <div id="root"></div>
   <script type="module" src="/index.tsx"></script>


### PR DESCRIPTION
## Summary
- remove importmap that loaded React from CDN, avoiding duplicate React copies causing hooks error

## Testing
- `npm run build` *(fails: Loading PostCSS Plugin failed: Cannot find module 'tailwindcss')*


------
https://chatgpt.com/codex/tasks/task_e_68b76f28cb74832aac19483873cd8968