### PR TITLE
Ensure numeric price calculations in snack bar POS page

### DIFF
--- a/pages/snackbar/SnackBarPOSPage.tsx
+++ b/pages/snackbar/SnackBarPOSPage.tsx
@@ -49,7 +49,7 @@ const SnackBarPOSPage: React.FC = () => {
     }, []);
     
     const addToOrder = (product: SnackBarProduct, isHalf: boolean = false, comboId?: string) => {
-        let price = isHalf && product.halfPrice ? product.halfPrice : product.sellPrice;
+        let price = Number(isHalf && product.halfPrice ? product.halfPrice : product.sellPrice);
         if (comboId) price = 0;
         const existingItemIndex = order.findIndex(item => item.productId === product.id && item.isHalf === isHalf && item.comboId === comboId);
         
@@ -63,8 +63,8 @@ const SnackBarPOSPage: React.FC = () => {
                 productId: product.id,
                 productName: product.name + (isHalf ? ' (1/2)' : ''),
                 quantity: 1,
-                unitPrice: price,
-                totalPrice: price,
+                unitPrice: Number(price),
+                totalPrice: Number(price),
                 isHalf: isHalf,
                 delivery: product.delivery,
                 comboId,
@@ -115,7 +115,7 @@ const SnackBarPOSPage: React.FC = () => {
                 {
                     comboId: comboToAdd.id,
                     comboName: comboToAdd.name,
-                    price: comboToAdd.price,
+                    price: Number(comboToAdd.price),
                     items: comboItems,
                 },
             ]);
@@ -183,8 +183,10 @@ const SnackBarPOSPage: React.FC = () => {
         }
     };
 
-    const totalStandalone = order.filter(item => !item.comboId).reduce((sum, item) => sum + item.totalPrice, 0);
-    const comboTotal = selectedCombos.reduce((sum, c) => sum + c.price, 0);
+    const totalStandalone = order
+        .filter(item => !item.comboId)
+        .reduce((sum, item) => sum + Number(item.totalPrice), 0);
+    const comboTotal = selectedCombos.reduce((sum, c) => sum + Number(c.price), 0);
     const total = totalStandalone + comboTotal;
 
     const categories = [...new Set(products.map(p => p.category)), ...(combos.length ? ['Combos'] : [])];


### PR DESCRIPTION
## Summary
- Cast product prices to numbers when adding snack bar items
- Force arithmetic addition by converting totals to numbers in reducers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_68b79ba4cdb8832ab1f8034213edcd9c