### PR TITLE
feat: close table modal when navigating or cancelling

### DIFF
--- a/pages/snackbar/SnackBarPOSPage.tsx
+++ b/pages/snackbar/SnackBarPOSPage.tsx
@@ -1,11 +1,12 @@
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { SnackBarProduct, OrderItem, SnackBarSale, SnackBarCombo, OrderCombo, OrderComboItem } from '../../types';
 import { getSnackBarProducts, getSnackBarCombos, confirmSale } from '../../services/api';
 import Modal from '../../components/Modal';
 import TicketModal from './TicketModal';
 import TableNumberModal from './TableNumberModal';
 import ComboModal from './ComboModal';
+import { useLocation } from 'react-router-dom';
 
 const SnackBarPOSPage: React.FC = () => {
     const [products, setProducts] = useState<SnackBarProduct[]>([]);
@@ -25,6 +26,15 @@ const SnackBarPOSPage: React.FC = () => {
     const [comboToAdd, setComboToAdd] = useState<SnackBarCombo | null>(null);
     const [lastSale, setLastSale] = useState<SnackBarSale | null>(null);
     const [paymentMethod, setPaymentMethod] = useState<'Efectivo' | 'Transferencia' | 'Tarjeta'>('Efectivo');
+
+    const location = useLocation();
+    const initialPath = useRef(location.pathname);
+
+    useEffect(() => {
+        if (location.pathname !== initialPath.current) {
+            setIsTableModalOpen(false);
+        }
+    }, [location.pathname]);
 
     const fetchProducts = async () => {
         try {
@@ -323,6 +333,7 @@ const SnackBarPOSPage: React.FC = () => {
 
                     setIsTableModalOpen(false);
                 }}
+                onClose={() => setIsTableModalOpen(false)}
             />
         </div>
     );

--- a/pages/snackbar/TableNumberModal.tsx
+++ b/pages/snackbar/TableNumberModal.tsx
@@ -5,12 +5,11 @@ import Modal from '../../components/Modal';
 
 interface TableNumberModalProps {
     isOpen: boolean;
-
     onSelect: (number: number, customerName?: string) => void;
-
+    onClose?: () => void;
 }
 
-const TableNumberModal: React.FC<TableNumberModalProps> = ({ isOpen, onSelect }) => {
+const TableNumberModal: React.FC<TableNumberModalProps> = ({ isOpen, onSelect, onClose }) => {
     const numbers = Array.from({ length: 20 }, (_, i) => i + 1);
 
     const [customerName, setCustomerName] = useState('');
@@ -21,7 +20,7 @@ const TableNumberModal: React.FC<TableNumberModalProps> = ({ isOpen, onSelect })
     };
 
     return (
-        <Modal isOpen={isOpen} onClose={() => {}} title="Seleccionar mesa" hideCloseButton>
+        <Modal isOpen={isOpen} onClose={onClose ?? (() => {})} title="Seleccionar mesa">
             <div className="mb-4">
                 <input
                     type="text"


### PR DESCRIPTION
## Summary
- allow TableNumberModal to accept an optional onClose and expose Modal's close button
- close the table modal when navigating to a different section or hitting cancel

## Testing
- `npm install` *(fails: ENOTEMPTY: directory not empty, rename '/workspace/gestionteatro/node_modules/fast-glob' -> '/workspace/gestionteatro/node_modules/.fast-glob-2JlLS7bV')*
- `npm run build` *(fails: Cannot find module 'tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_68b79ba946f4832aae6fe45887e2134e