### PR TITLE
Use shared combo endpoint in snack bar

### DIFF
--- a/backend/controllers/snackBarController.js
+++ b/backend/controllers/snackBarController.js
@@ -1,22 +1,36 @@
 
 import SnackBarProduct from '../models/SnackBarProduct.js';
 import SnackBarPurchase from '../models/SnackBarPurchase.js';
-
-const combos = [
-  {
-    id: 'combo1',
-    name: 'Combo Pizza + Bebida',
-    price: 7000,
-    components: [
-      { id: 'pizza', name: 'Pizza', options: ['p4', 'p5'] },
-      { id: 'drink', name: 'Bebida', options: ['p1', 'p2', 'p3'] },
-    ],
-  },
-];
+import Combo from '../models/Combo.js';
+import ComboItem from '../models/ComboItem.js';
 
 export const getSnackBarCombos = async (req, res) => {
   try {
-    res.json(combos);
+    const combos = await Combo.findAll({
+      include: {
+        model: ComboItem,
+        as: 'components',
+        include: {
+          model: SnackBarProduct,
+          as: 'options',
+          attributes: ['id'],
+          through: { attributes: [] },
+        },
+      },
+    });
+
+    const formatted = combos.map((combo) => ({
+      id: combo.id,
+      name: combo.name,
+      price: combo.price,
+      components: combo.components.map((item) => ({
+        id: item.id,
+        name: item.name,
+        options: item.options.map((p) => p.id),
+      })),
+    }));
+
+    res.json(formatted);
   } catch (error) {
     res.status(500).json({ message: error.message });
   }

--- a/pages/snackbar/ComboModal.tsx
+++ b/pages/snackbar/ComboModal.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import Modal from '../../components/Modal';
-import { SnackBarCombo, SnackBarProduct } from '../../types';
+import { Combo, SnackBarProduct } from '../../types';
 
 interface ComboModalProps {
     isOpen: boolean;
-    combo: SnackBarCombo | null;
+    combo: Combo | null;
     products: SnackBarProduct[];
     onConfirm: (selection: { [componentId: string]: string }) => void;
     onClose: () => void;
@@ -25,7 +25,7 @@ const ComboModal: React.FC<ComboModalProps> = ({ isOpen, combo, products, onConf
         setSelected(prev => ({ ...prev, [componentId]: productId }));
     };
 
-    const allSelected = combo.components.every(c => selected[c.id]);
+    const allSelected = combo.components.every(c => selected[String(c.id)]);
 
     const confirm = () => {
         if (allSelected) {
@@ -40,13 +40,13 @@ const ComboModal: React.FC<ComboModalProps> = ({ isOpen, combo, products, onConf
                     <p className="font-semibold mb-2 text-gray-800 dark:text-white">{component.name}</p>
                     <div className="grid grid-cols-2 gap-2">
                         {products
-                            .filter(p => component.options.includes(p.id))
+                            .filter(p => component.productIds.includes(p.id))
                             .map(p => (
                                 <button
                                     key={p.id}
-                                    onClick={() => handleSelect(component.id, p.id)}
+                                    onClick={() => handleSelect(String(component.id), p.id)}
                                     className={`p-2 rounded border text-left ${
-                                        selected[component.id] === p.id
+                                        selected[String(component.id)] === p.id
                                             ? 'bg-brand-accent text-white'
                                             : 'bg-gray-100 dark:bg-brand-blue text-gray-800 dark:text-white'
                                     }`}

--- a/pages/snackbar/SnackBarPOSPage.tsx
+++ b/pages/snackbar/SnackBarPOSPage.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
-import { SnackBarProduct, OrderItem, SnackBarSale, SnackBarCombo, OrderCombo, OrderComboItem } from '../../types';
-import { getSnackBarProducts, getSnackBarCombos, confirmSale } from '../../services/api';
+import { SnackBarProduct, OrderItem, SnackBarSale, Combo, OrderCombo, OrderComboItem } from '../../types';
+import { getSnackBarProducts, getCombos, confirmSale } from '../../services/api';
 import Modal from '../../components/Modal';
 import TicketModal from './TicketModal';
 import TableNumberModal from './TableNumberModal';
@@ -10,7 +10,7 @@ import { useLocation } from 'react-router-dom';
 
 const SnackBarPOSPage: React.FC = () => {
     const [products, setProducts] = useState<SnackBarProduct[]>([]);
-    const [combos, setCombos] = useState<SnackBarCombo[]>([]);
+    const [combos, setCombos] = useState<Combo[]>([]);
     const [order, setOrder] = useState<OrderItem[]>([]);
     const [selectedCombos, setSelectedCombos] = useState<OrderCombo[]>([]);
     const [tableNumber, setTableNumber] = useState<number>(0);
@@ -23,7 +23,7 @@ const SnackBarPOSPage: React.FC = () => {
     const [isTableModalOpen, setIsTableModalOpen] = useState(true);
     const [pizzaToAdd, setPizzaToAdd] = useState<SnackBarProduct | null>(null);
     const [isComboModalOpen, setIsComboModalOpen] = useState(false);
-    const [comboToAdd, setComboToAdd] = useState<SnackBarCombo | null>(null);
+    const [comboToAdd, setComboToAdd] = useState<Combo | null>(null);
     const [lastSale, setLastSale] = useState<SnackBarSale | null>(null);
     const [paymentMethod, setPaymentMethod] = useState<'Efectivo' | 'Transferencia' | 'Tarjeta'>('Efectivo');
 
@@ -42,7 +42,7 @@ const SnackBarPOSPage: React.FC = () => {
             setError(null);
             const [productsData, combosData] = await Promise.all([
                 getSnackBarProducts(),
-                getSnackBarCombos(),
+                getCombos(),
             ]);
             setProducts(productsData);
             setCombos(combosData);
@@ -92,7 +92,7 @@ const SnackBarPOSPage: React.FC = () => {
         }
     };
 
-    const handleComboClick = (combo: SnackBarCombo) => {
+    const handleComboClick = (combo: Combo) => {
         setComboToAdd(combo);
         setIsComboModalOpen(true);
     };

--- a/services/api.ts
+++ b/services/api.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import { Workshop, Student, Show, SnackBarProduct, SnackBarProductCategory, SnackBarProductDelivery, KitchenOrder, OrderItem, SnackBarSale, SnackBarCombo, OrderCombo, Combo } from '../types';
+import { Workshop, Student, Show, SnackBarProduct, SnackBarProductCategory, SnackBarProductDelivery, KitchenOrder, OrderItem, SnackBarSale, OrderCombo, Combo } from '../types';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
@@ -93,11 +93,6 @@ export const getShowById = async (id: string): Promise<Show> => {
 
 export const getSnackBarProducts = async (): Promise<SnackBarProduct[]> => {
     const response = await api.get('/snackbar');
-    return response.data;
-};
-
-export const getSnackBarCombos = async (): Promise<SnackBarCombo[]> => {
-    const response = await api.get('/snackbar/combos');
     return response.data;
 };
 

--- a/types.ts
+++ b/types.ts
@@ -75,19 +75,6 @@ export interface SnackBarProduct {
     halfPrice?: number;
 }
 
-export interface SnackBarComboComponent {
-    id: string;
-    name: string;
-    options: string[]; // product IDs allowed for this component
-}
-
-export interface SnackBarCombo {
-    id: string;
-    name: string;
-    price: number;
-    components: SnackBarComboComponent[];
-}
-
 export interface OrderComboItem {
     productId: string;
     productName: string;


### PR DESCRIPTION
## Summary
- Load snack bar combos from the shared Combo model instead of a hardcoded array
- Expose a single `getCombos` API method and reuse it in the snack bar POS
- Replace legacy SnackBarCombo types with shared Combo definitions

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b84f373af4832ab13569936ae63a80