### PR TITLE
chore: add vitest testing setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "axios": "^1.10.0",
@@ -25,6 +27,11 @@
     "vite": "^6.2.0",
     "tailwindcss": "^3.4.4",
     "postcss": "^8.4.31",
-    "autoprefixer": "^10.4.16"
+    "autoprefixer": "^10.4.16",
+    "vitest": "*",
+    "@vitest/ui": "*",
+    "jsdom": "*",
+    "@testing-library/react": "*",
+    "@testing-library/jest-dom": "*"
   }
 }

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/setupTests.ts'
+  }
+});


### PR DESCRIPTION
## Summary
- add vitest configuration using jsdom and globals
- wire up test scripts and setup file for Testing Library

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b84fe8b818832abc057c6d9dbdd0f9