### PR TITLE
Add Jest testing scaffold with SQLite memory DB

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,9 @@
+export default {
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { useESM: true }]
+  },
+  setupFilesAfterEnv: ['<rootDir>/tests/setup.ts']
+};
+

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,10 +4,11 @@
   "description": "Backend for Onírico Sur Theater Management System",
   "type": "module",
   "main": "server.js",
-  "type": "module",
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "test": "cross-env NODE_ENV=test jest",
+    "test:watch": "cross-env NODE_ENV=test jest --watch"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -18,6 +19,12 @@
     "uuid": "^11.1.0"
   },
   "devDependencies": {
-    "nodemon": "^3.0.1"
+    "nodemon": "^3.0.1",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4",
+    "cross-env": "^7.0.3",
+    "@types/jest": "^29.5.11",
+    "ts-jest": "^29.1.1",
+    "sqlite3": "^5.1.7"
   }
 }

--- a/backend/tests/setup.ts
+++ b/backend/tests/setup.ts
@@ -1,0 +1,15 @@
+import { Sequelize } from 'sequelize';
+
+// SQLite in-memory database for tests
+export const sequelize = new Sequelize('sqlite::memory:', {
+  logging: false,
+});
+
+beforeAll(async () => {
+  await sequelize.authenticate();
+});
+
+afterAll(async () => {
+  await sequelize.close();
+});
+

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts"]
+}
+


### PR DESCRIPTION
## Summary
- add Jest-based testing setup with ESM and TypeScript support
- scaffold in-memory SQLite bootstrap for backend tests

## Testing
- `npm test --prefix backend` *(fails: cross-env not found due to package installation issues)*

------
https://chatgpt.com/codex/tasks/task_e_68b84feb15a0832aaecf326565161605