### PR TITLE
Add Bebida snack bar category

### DIFF
--- a/backend/models/SnackBarProduct.js
+++ b/backend/models/SnackBarProduct.js
@@ -12,7 +12,7 @@ const SnackBarProduct = sequelize.define('SnackBarProduct', {
     allowNull: false,
   },
   category: {
-    type: DataTypes.ENUM('Bebida', 'Pizza', 'Empanada', 'Trago', 'Snack'),
+    type: DataTypes.ENUM('Bebida', 'Trago', 'Pizza', 'Empanada', 'Snack'),
     allowNull: false,
   },
   brand: {

--- a/components/ProductForm.tsx
+++ b/components/ProductForm.tsx
@@ -8,7 +8,7 @@ const ProductForm: React.FC = () => {
     const navigate = useNavigate();
     const [product, setProduct] = useState<Partial<SnackBarProduct>>({
         name: '',
-        category: SnackBarProductCategory.Beer,
+        category: SnackBarProductCategory.Bebida,
         purchasePrice: 0,
         sellPrice: 0,
         stock: 0,

--- a/pages/products/ProductManagementPage.tsx
+++ b/pages/products/ProductManagementPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { SnackBarProduct, SnackBarProductCategory, SnackBarProductDelivery } from '../../types';
+import { SnackBarProduct, SnackBarProductDelivery } from '../../types';
 import { getSnackBarProducts, deleteSnackBarProduct } from '../../services/api';
 import { Link } from 'react-router-dom';
 import { Edit, Trash2, PlusCircle } from 'lucide-react';

--- a/pages/products/__tests__/ComboBuilderPage.test.tsx
+++ b/pages/products/__tests__/ComboBuilderPage.test.tsx
@@ -25,7 +25,7 @@ const mockProducts = [
   {
     id: '1',
     name: 'Beer',
-    category: SnackBarProductCategory.Beer,
+    category: SnackBarProductCategory.Bebida,
     purchasePrice: 10,
     sellPrice: 20,
     stock: 100,
@@ -85,7 +85,7 @@ describe('ComboBuilderPage', () => {
     const categorySelect = screen.getByRole('listbox');
     fireEvent.change(categorySelect, {
       target: {
-        selectedOptions: [{ value: SnackBarProductCategory.Beer }],
+        selectedOptions: [{ value: SnackBarProductCategory.Bebida }],
       },
     });
 

--- a/types.ts
+++ b/types.ts
@@ -46,10 +46,10 @@ export interface Show {
 }
 
 export enum SnackBarProductCategory {
-  Drink = "Bebida",
+  Bebida = "Bebida",
+  Trago = "Trago",
   Pizza = "Pizza",
   Empanada = "Empanada",
-  Cocktail = "Trago",
   Snack = "Snack",
 }
 


### PR DESCRIPTION
## Summary
- allow `Bebida` as a snack bar product category in Sequelize model and types
- update product form and combo builder test to use the new category
- remove unused category import on product management page

## Testing
- `npm test` *(fails: vitest: not found)*
- `node -e <migration>` *(fails: Cannot find package 'sequelize')*


------
https://chatgpt.com/codex/tasks/task_e_68bdd2b3ae18832ab3801138f5ba18a8